### PR TITLE
bug: import web api hangs on import command exec

### DIFF
--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -15,7 +15,11 @@ import (
 
 const MaxErrorLogCalls = 20000
 
-func CreateAction(databasePath *string, leakPath *string, context *string, platforms *cli.StringSlice, shareDate *cli.Timestamp, leakers *cli.StringSlice, notifyNewLeakURL *string, storeImport func(databasePath string, i query.Import) (entity.AutoGenKey, error), notifyImport func(entity.AutoGenKey, string) error) func(cCtx *cli.Context) error {
+func CreateAction(databasePath *string, leakPath *string, context *string, platforms *cli.StringSlice,
+	shareDate *cli.Timestamp, leakers *cli.StringSlice, notifyNewLeakURL *string, skipInteractiveMode *bool,
+	storeImport func(databasePath string, i query.Import) (entity.AutoGenKey, error),
+	notifyImport func(entity.AutoGenKey, string) error,
+) func(cCtx *cli.Context) error {
 	return func(cCtx *cli.Context) error {
 		logging.Aspirador.Info("Starting Import")
 
@@ -53,17 +57,19 @@ func CreateAction(databasePath *string, leakPath *string, context *string, platf
 				}
 			}
 
-			fmt.Println("Proceed with import?")
-			reader := bufio.NewReader(os.Stdin)
-			input, _, errRead := reader.ReadLine()
+			if !*skipInteractiveMode {
+				fmt.Println("Proceed with import?")
+				reader := bufio.NewReader(os.Stdin)
+				input, _, errRead := reader.ReadLine()
 
-			if errRead != nil {
-				return errRead
-			}
+				if errRead != nil {
+					return errRead
+				}
 
-			if !IsProceedAnswer(proceedAnswers, strings.ToLower(string(input))) {
-				logging.Aspirador.Info("Stopped import")
-				return nil
+				if !IsProceedAnswer(proceedAnswers, strings.ToLower(string(input))) {
+					logging.Aspirador.Info("Stopped import")
+					return nil
+				}
 			}
 		}
 

--- a/internal/cli/alias.go
+++ b/internal/cli/alias.go
@@ -7,3 +7,4 @@ var AliasesFlagLeakPlatforms = []string{"p"}
 var AliasesFlagLeakShareDate = []string{"sd"}
 var AliasesFlagLeakers = []string{"l"}
 var AliasesFlagNotifyNewLeakURL = []string{"notify-url"}
+var AliasesFlagSkipInteractiveMode = []string{"skip"}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,7 @@ func CreateCliApp(storeImport func(databasePath string, i query.Import) (entity.
 	var shareDate cli.Timestamp
 	var leakers cli.StringSlice
 	var notifyNewLeakURL string
+	var skipInteractiveMode bool
 
 	app := &cli.App{
 		Name:                 "import",
@@ -30,8 +31,8 @@ func CreateCliApp(storeImport func(databasePath string, i query.Import) (entity.
 		HideHelp:             false,
 		HideVersion:          false,
 		Authors:              CreateCliAuthors(),
-		Flags:                CreateCliFlags(&databasePath, &leakPath, &context, &platforms, &shareDate, &leakers, &notifyNewLeakURL),
-		Action:               CreateAction(&databasePath, &leakPath, &context, &platforms, &shareDate, &leakers, &notifyNewLeakURL, storeImport, notifyImport),
+		Flags:                CreateCliFlags(&databasePath, &leakPath, &context, &platforms, &shareDate, &leakers, &notifyNewLeakURL, &skipInteractiveMode),
+		Action:               CreateAction(&databasePath, &leakPath, &context, &platforms, &shareDate, &leakers, &notifyNewLeakURL, &skipInteractiveMode, storeImport, notifyImport),
 	}
 
 	cli.AppHelpTemplate = CreateAppHelpTemplate(cli.AppHelpTemplate)

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -6,16 +6,20 @@ import (
 )
 
 const (
-	FlagDatabasePath     = "database-path"
-	FlagLeakPath         = "leak-path"
-	FlagLeakContext      = "context"
-	FlagLeakPlatforms    = "platforms"
-	FlagLeakShareDate    = "share-date"
-	FlagLeakers          = "leakers"
-	FlagNotifyNewLeakURL = "notify url"
+	FlagDatabasePath        = "database-path"
+	FlagLeakPath            = "leak-path"
+	FlagLeakContext         = "context"
+	FlagLeakPlatforms       = "platforms"
+	FlagLeakShareDate       = "share-date"
+	FlagLeakers             = "leakers"
+	FlagNotifyNewLeakURL    = "notify url"
+	FlagSkipInteractiveMode = "skip-interactive-mode"
 )
 
-func CreateCliFlags(databasePath *string, leakPath *string, context *string, platforms *cli.StringSlice, shareDate *cli.Timestamp, leakers *cli.StringSlice, notifyNewLeakURL *string) []cli.Flag {
+func CreateCliFlags(databasePath *string, leakPath *string, context *string,
+	platforms *cli.StringSlice, shareDate *cli.Timestamp, leakers *cli.StringSlice,
+	notifyNewLeakURL *string, skipInteractiveMode *bool,
+) []cli.Flag {
 
 	return []cli.Flag{
 		&cli.PathFlag{
@@ -68,6 +72,14 @@ func CreateCliFlags(databasePath *string, leakPath *string, context *string, pla
 			Usage:       "URL service to be notified of the new leak",
 			Required:    true,
 			Destination: notifyNewLeakURL,
+		},
+		&cli.BoolFlag{
+			Name:        FlagSkipInteractiveMode,
+			Aliases:     AliasesFlagSkipInteractiveMode,
+			Usage:       "Whether to skip questions the program might question you before taking any action",
+			Required:    false,
+			Value:       false,
+			Destination: skipInteractiveMode,
 		},
 	}
 }

--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -6,7 +6,7 @@ import (
 	"github.com/palavrapasse/damn/pkg/entity/query"
 )
 
-var exampleCommand = fmt.Sprintf(`./import --database-path="path/db.sqlite" --leak-path="path/file.txt" --context="context" --platforms="platform1, platform2" --share-date="%s" --leakers="leaker1, leaker2" --notify-url="https://subscribeService/notify"`,
+var exampleCommand = fmt.Sprintf(`./import --database-path="path/db.sqlite" --leak-path="path/file.txt" --context="context" --platforms="platform1, platform2" --share-date="%s" --leakers="leaker1, leaker2" --notify-url="https://subscribeService/notify" --skip=false`,
 	query.DateFormatLayout)
 
 func CreateAppHelpTemplate(base string) string {

--- a/third_party/import-web-api/index.js
+++ b/third_party/import-web-api/index.js
@@ -24,7 +24,7 @@ const leakFormSchema = {
 };
 
 function triggerImportLeak(leakForm) {
-    const cmd = `./import --database-path="${leaksDbFilePath}" --leak-path="${leakForm.leakFile}" --context="${leakForm.context}" --platforms="${leakForm.platforms}" --share-date="${leakForm.shareDate}" --leakers="${leakForm.leakers}" --notify-url="${subscribeNotifyUrl}"`;
+    const cmd = `./import --database-path="${leaksDbFilePath}" --leak-path="${leakForm.leakFile}" --context="${leakForm.context}" --platforms="${leakForm.platforms}" --share-date="${leakForm.shareDate}" --leakers="${leakForm.leakers}" --notify-url="${subscribeNotifyUrl}" --skip=true`;
     console.info(cmd);
 
     exec(cmd, function (error, stdout, stderr) {


### PR DESCRIPTION
by default, import cli tool asks the person who is triggering the import to confirm via keyboard input if he really wants to proceed with the leak import. this keyboard interactivity blocks the command call import-web-api executes, so we need to include a flag that allows to bypass such interactivity